### PR TITLE
Allow use for Device 4

### DIFF
--- a/devise_custom_authenticatable.gemspec
+++ b/devise_custom_authenticatable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.0"
+  spec.add_development_dependency "activemodel", ">= 3.1"
 
-  spec.add_dependency "devise", ">= 2", "< 4"
-
+  spec.add_dependency "devise", ">= 2", "< 5"
 end

--- a/spec/devise/models/custom_authenticatable_spec.rb
+++ b/spec/devise/models/custom_authenticatable_spec.rb
@@ -21,18 +21,18 @@ describe Devise::Models::CustomAuthenticatable do
         expect(@it).to receive(:authenticated_by_test1_strategy?).with('password').and_return(false)
         expect(@it).to receive(:authenticated_by_test2_strategy?).and_return(false)
 
-        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_false
+        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_falsey
       end
 
       it "return true if any of them return true" do
         expect(@it).to receive(:authenticated_by_test1_strategy?).with('password').and_return(false)
         expect(@it).to receive(:authenticated_by_test2_strategy?).and_return(true)
 
-        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_true
+        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_truthy
       end
 
       it "return true if all of them return true" do
-        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_true
+        expect(@it.authenticated_by_any_custom_strategy?('password', :test1, :test2)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Additional:
- Fix test deprecated warnings 
- Add activemodel as development dependency to fix 'cannot load such file -- active_model/version' issue by running tests
